### PR TITLE
fix github login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-leetcode-problem-rating",
-    "version": "2.19.14",
+    "version": "3.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-leetcode-problem-rating",
-            "version": "2.19.14",
+            "version": "3.1.4",
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-leetcode-problem-rating",
     "displayName": "LeetCode",
     "description": "%main.description%",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "author": "ccagml",
     "publisher": "ccagml",
     "license": "MIT",

--- a/src/rpc/actionChain/chainNode/leetcode.ts
+++ b/src/rpc/actionChain/chainNode/leetcode.ts
@@ -579,7 +579,7 @@ and csrf token to the user object and saves the user object to the session. */
         if (resp.statusCode !== 200) {
           return cb("GitHub login failed");
         }
-        if (resp.request.uri.href !== urls.github_tf_redirect) {
+        if (!resp.request.uri.href.startsWith(urls.github_tf_redirect)) {
           return that.requestLeetcodeAndSave(_request, leetcodeUrl, user, cb);
         }
         prompt_out.colors = false;


### PR DESCRIPTION
Resolved GitHub 2FA Login Issue for OTP Generated by Authenticator App

I have successfully addressed the GitHub login issue related to 2FA authentication when utilizing OTPs generated by the Authenticator app. To ensure seamless functionality, it is now imperative for users to have the Authenticator app as their preferred 2FA method. Please note that support for SMS/Github Mobile 2FA to be added in the future upon request.