### PR TITLE
fix windows build bug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,6 +53,13 @@
                 "-rf",
                 "out"
             ],
+            "windows": {
+                "command": "Remove-item",
+                "args": [
+                    "out",
+                    "-recurse"
+                ],
+            }
             // "isBackground": true,
         },
         {


### PR DESCRIPTION
When building the extension on Windows with WSL installed, the npm 'master' branch was detected instead of 'windows_master', resulting in an error.

'The terminal process "C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -Command rm -rf out" terminated with exit code: 1.'

By adding OS-based detection, the extension can be built correctly across all OS systems.

PS: Did not check the branching logic in .vscode/launch.json, we might be able to ditch the 'windows_master' branch altogether by adding OS-based conditions to all tasks. (Currently, the only difference is using 'rm' or 'Remove-item', which can be done inline relatively easily using only OS-based conditions)