### PR TITLE
fix description button not working error

### DIFF
--- a/src/questionData/QuestionDataModule.ts
+++ b/src/questionData/QuestionDataModule.ts
@@ -92,7 +92,14 @@ export class QuestionDataProxy extends BABAProxy {
   }
 
   public getNodeById(id: string): TreeNodeModel | undefined {
-    return this.getfidMapQuestionData().get(id);
+    let map = this.getfidMapQuestionData();
+    if (map.has(id)) {
+      return map.get(id);
+    } else if (map.has(parseInt(id))) {
+      return map.get(parseInt(id));
+    } else {
+      return undefined;
+    }
   }
 
   public getNodeByQid(qid: string): TreeNodeModel | undefined {


### PR DESCRIPTION
The map linking IDs to TreeNodeModel was defined to use string keys, but during runtime, integer keys are being encountered. To address this issue, I implemented checks to ensure that both key types are parsed correctly. However, it's crucial to conduct further investigation to determine the root cause of this discrepancy and confirm that the map's intended key type is indeed string.