### PR TITLE
Correct syntax error for python debug entry

### DIFF
--- a/resources/debug/entry/python3/entry.py
+++ b/resources/debug/entry/python3/entry.py
@@ -268,7 +268,7 @@ def parseParameter(index, paramType, param):
     }
     switchfun = switch.get(paramType, 0)
 
-    if switchfun is 0:
+    if switchfun == 0:
         result = parseSpecialParameter(index, paramType, param)
         if result is None:
             onParameterTypeError(paramType)


### PR DESCRIPTION
Use equal signs instead of 'is'