### PR TITLE
添加msvc支持，使用path中的clang，gcc使用c++20标准

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,9 @@
             ],
             "trace": false,
             "preLaunchTask": "npm",
+            "env": {
+                "PATH": "${env:PATH}"
+            }
         },
         {
             "type": "node",

--- a/package.json
+++ b/package.json
@@ -1196,11 +1196,13 @@
                         "default": "gdb",
                         "enum": [
                             "gdb",
-                            "clang"
+                            "clang",
+                            "msvc"
                         ],
                         "enumDescriptions": [
                             "%main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.0%",
-                            "%main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1%"
+                            "%main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1%",
+                            "%main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.2%"
                         ],
                         "scope": "resource"
                     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -104,7 +104,8 @@
     "main.contributes.configuration.properties.leetcode-problem-rating.openClearProblemCacheTime.description": "Open the app to clear the cache interval by default 3600 seconds",
     "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions": [
         "gdb compiler",
-        "clang compiler"
+        "clang compiler",
+        "msvc compiler"
     ],
     "main.contributes.configuration.properties.leetcode-problem-rating.problems.sortStrategy.enumDescriptions.0": "None",
     "main.contributes.configuration.properties.leetcode-problem-rating.problems.sortStrategy.enumDescriptions.1": "Acceptance Rate (Ascending)",
@@ -126,5 +127,6 @@
     "main.contributes.configuration.properties.leetcode-problem-rating.hideScore.enumDescriptions.2": "Hide questions with no scores",
     "main.contributes.configuration.properties.leetcode-problem-rating.hideScore.enumDescriptions.3": "Hide questions outside the range of scores [pickOneByRankRangeMin, pickOneByRankRangeMax]",
     "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.0": "gdb compiler",
-    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1": "clang compiler"
+    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1": "clang compiler",
+    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.2": "msvc compiler"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -104,7 +104,8 @@
     "main.contributes.configuration.properties.leetcode-problem-rating.openClearProblemCacheTime.description": "打开拓展时清除缓存间隔默认3600秒",
     "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions": [
         "gdb compiler",
-        "clang compiler"
+        "clang compiler",
+        "msvc compiler"
     ],
     "main.contributes.configuration.properties.leetcode-problem-rating.problems.sortStrategy.enumDescriptions.0": "默认题目编号排序",
     "main.contributes.configuration.properties.leetcode-problem-rating.problems.sortStrategy.enumDescriptions.1": "通过率升序",
@@ -126,5 +127,6 @@
     "main.contributes.configuration.properties.leetcode-problem-rating.hideScore.enumDescriptions.2": "隐藏没有分数的题目",
     "main.contributes.configuration.properties.leetcode-problem-rating.hideScore.enumDescriptions.3": "隐藏分数在配置[pickOneByRankRangeMin, pickOneByRankRangeMax]范围外的题目",
     "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.0": "gdb编译",
-    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1": "clang编译"
+    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.1": "clang编译",
+    "main.contributes.configuration.properties.leetcode-problem-rating.cppCompiler.enumDescriptions.2": "msvc编译",
 }


### PR DESCRIPTION
1.  添加了 msvc 的支持，需要在 `Developer PowerShell` 或 `Developer Command Prompt` 中打开 vscode 以添加环境变量
2.  clang 路径由 `/usr/bin/clang++` 修改为 `clang++`
3.  修改了 clang 对应的调试配置，使用 mingw-llvm 工具链时能正常 debug（依赖 `CodeLLDB` 扩展）
4.  gcc 使用c++20标准