### PR TITLE
feat(favorite): 多级收藏夹树与指定列表增删题目

### DIFF
--- a/src/BABA.ts
+++ b/src/BABA.ts
@@ -140,6 +140,10 @@ export enum BabaStr {
   RecentContestMediator = "RecentContestMediator",
   ContestQuestionProxy = "ContestQuestionProxy",
   ContestQuestionMediator = "ContestQuestionMediator",
+  FavoriteDataProxy = "FavoriteDataProxy",
+  FavoriteDataMediator = "FavoriteDataMediator",
+  TreeData_searchFavoriteListsFinish = "TreeData_searchFavoriteListsFinish",
+  TreeData_searchFavoriteQuestionsFinish = "TreeData_searchFavoriteQuestionsFinish",
 }
 
 export class BABA {

--- a/src/childCall/childCallModule.ts
+++ b/src/childCall/childCallModule.ts
@@ -308,6 +308,25 @@ class ExecuteService implements Disposable {
     return solution;
   }
 
+  public async getFavoriteLists(): Promise<string> {
+    const cmd: string[] = [await this.getLeetCodeBinaryPath(), "query", "-k"];
+    const solution: string = await this.callWithMsg("正在获取收藏夹~", this.nodeExecutable, cmd);
+    return solution;
+  }
+
+  public async getFavoriteQuestions(favoriteSlug: string, favoriteHash: string): Promise<string> {
+    const cmd: string[] = [
+      await this.getLeetCodeBinaryPath(),
+      "query",
+      "-l",
+      favoriteSlug,
+      "-m",
+      favoriteHash,
+    ];
+    const solution: string = await this.callWithMsg("正在获取收藏夹题目~", this.nodeExecutable, cmd);
+    return solution;
+  }
+
   public async getDescription(problemNodeId: string, needTranslation: boolean): Promise<string> {
     const cmd: string[] = [await this.getLeetCodeBinaryPath(), "show", problemNodeId, "-x"];
     if (!needTranslation) {
@@ -407,12 +426,51 @@ class ExecuteService implements Disposable {
     }
   }
 
-  public async toggleFavorite(node: TreeNodeModel, addToFavorite: boolean): Promise<void> {
-    const commandParams: string[] = [await this.getLeetCodeBinaryPath(), "star", node.qid];
+  public async toggleFavorite(
+    node: TreeNodeModel,
+    addToFavorite: boolean,
+    favoriteHash?: string
+  ): Promise<void> {
+    const nodeData = node.get_data?.() || (node as any).__DataPool?.get?.(node.nodeType) || {};
+    const keyword = nodeData.favoriteQuestionId || node.qid || node.id;
+    const commandParams: string[] = [await this.getLeetCodeBinaryPath(), "star", keyword];
     if (!addToFavorite) {
       commandParams.push("-d");
     }
-    await this.callWithMsg("正在更新收藏列表~", this.nodeExecutable, commandParams);
+    const hash = favoriteHash || node.input || nodeData.input;
+    if (hash) {
+      commandParams.push("-H", hash);
+    }
+    const result = await this.callWithMsg("正在更新收藏列表~", this.nodeExecutable, commandParams);
+    this.assertStarCommandResult(result);
+  }
+
+  private assertStarCommandResult(result: string): void {
+    const trimmed = (result || "").trim();
+    if (!trimmed) {
+      throw new Error("favorite command returned empty response");
+    }
+    const successLine =
+      trimmed
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.includes("icon.like") || line.includes("icon.unlike")) || trimmed;
+    if (successLine.includes("[object Object]")) {
+      throw new Error("favorite command failed");
+    }
+    if (successLine.startsWith("{")) {
+      const parsed = JSON.parse(successLine);
+      if (parsed?.error) {
+        throw new Error(parsed.error);
+      }
+      return;
+    }
+    if (successLine.startsWith("[error]")) {
+      throw new Error(successLine);
+    }
+    if (!successLine.includes("icon.like") && !successLine.includes("icon.unlike")) {
+      throw new Error(successLine);
+    }
   }
 
   public async trySignIn(loginMethod: string) {

--- a/src/controller/TreeViewController.ts
+++ b/src/controller/TreeViewController.ts
@@ -73,6 +73,16 @@ class TreeViewController implements Disposable {
   private waitTodayQuestion: boolean;
   private waitUserContest: boolean;
   private configurationChangeListener: Disposable;
+  private favoriteOpQueue: Promise<void> = Promise.resolve();
+
+  private enqueueFavoriteOp<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.favoriteOpQueue.then(op, op);
+    this.favoriteOpQueue = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
 
   constructor() {
     this.configurationChangeListener = workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
@@ -412,11 +422,27 @@ class TreeViewController implements Disposable {
    * It adds a node to the user's favorites
    * @param {TreeNodeModel} node - TreeNodeModel
    */
-  public async addFavorite(node: TreeNodeModel): Promise<void> {
-    try {
-      await BABA.getProxy(BabaStr.ChildCallProxy).get_instance().toggleFavorite(node, true);
+  public addFavorite(node: TreeNodeModel): Promise<void> {
+    return this.enqueueFavoriteOp(() => this.doAddFavorite(node));
+  }
 
-      BABA.sendNotification(BabaStr.TreeData_favoriteChange);
+  private async doAddFavorite(node: TreeNodeModel): Promise<void> {
+    try {
+      const nodeData = node.get_data();
+      const questionId = nodeData?.favoriteQuestionId || node.qid || node.id;
+      const favoriteHash =
+        node.input ||
+        nodeData?.input ||
+        BABA.getProxy(BabaStr.FavoriteDataProxy).findFavoriteHashForQuestion(questionId);
+      await BABA.getProxy(BabaStr.ChildCallProxy)
+        .get_instance()
+        .toggleFavorite(node, true, favoriteHash);
+      if (favoriteHash) {
+        BABA.getProxy(BabaStr.FavoriteDataProxy).addQuestionToList(favoriteHash, questionId);
+        BABA.getProxy(BabaStr.FavoriteDataProxy).refreshFavoriteQuestionsUI(favoriteHash);
+      } else {
+        BABA.sendNotification(BabaStr.TreeData_favoriteChange);
+      }
     } catch (error) {
       await ShowMessage("添加喜欢题目失败. 请查看控制台信息~", OutPutType.error);
     }
@@ -426,10 +452,29 @@ class TreeViewController implements Disposable {
    * It removes a node from the user's favorites
    * @param {TreeNodeModel} node - The node that is currently selected in the tree.
    */
-  public async removeFavorite(node: TreeNodeModel): Promise<void> {
+  public removeFavorite(node: TreeNodeModel): Promise<void> {
+    return this.enqueueFavoriteOp(() => this.doRemoveFavorite(node));
+  }
+
+  private async doRemoveFavorite(node: TreeNodeModel): Promise<void> {
     try {
-      await BABA.getProxy(BabaStr.ChildCallProxy).get_instance().toggleFavorite(node, false);
-      BABA.sendNotification(BabaStr.TreeData_favoriteChange);
+      const nodeData = node.get_data();
+      const questionId = nodeData?.favoriteQuestionId || node.qid || node.id;
+      const fid = node.id;
+      const favoriteHash =
+        node.input ||
+        nodeData?.input ||
+        BABA.getProxy(BabaStr.FavoriteDataProxy).findFavoriteHashForQuestion(questionId);
+      const favoriteProxy = BABA.getProxy(BabaStr.FavoriteDataProxy);
+      await BABA.getProxy(BabaStr.ChildCallProxy)
+        .get_instance()
+        .toggleFavorite(node, false, favoriteHash);
+      if (favoriteHash) {
+        favoriteProxy.removeQuestionFromList(favoriteHash, questionId, fid);
+        favoriteProxy.refreshFavoriteQuestionsUI(favoriteHash);
+      } else {
+        BABA.sendNotification(BabaStr.TreeData_favoriteChange);
+      }
     } catch (error) {
       await ShowMessage("移除喜欢题目失败. 请查看控制台信息~", OutPutType.error);
     }
@@ -1344,6 +1389,43 @@ class TreeViewController implements Disposable {
     }
     this.sortSubCategoryNodes(res, Category.Tag);
     return res;
+  }
+
+  public getFavoriteListChild(): TreeNodeModel[] {
+    const favoriteProxy = BABA.getProxy(BabaStr.FavoriteDataProxy);
+    if (!favoriteProxy.isListsLoaded()) {
+      if (!favoriteProxy.isLoadingLists()) {
+        favoriteProxy.searchFavoriteLists();
+      }
+      return [];
+    }
+    const lists = favoriteProxy.getAllFavoriteListTreeNodes();
+    const res: TreeNodeModel[] = [];
+    for (const list of lists) {
+      res.push(CreateTreeNodeModel(list, TreeNodeType.Tree_favorite_fenlei));
+    }
+    return res;
+  }
+
+  public getFavoriteQuestionNodes(element: TreeNodeModel): TreeNodeModel[] {
+    const favoriteProxy = BABA.getProxy(BabaStr.FavoriteDataProxy);
+    const hash = element.id;
+    if (!favoriteProxy.isListsLoaded() || !favoriteProxy.isQuestionsLoaded(hash)) {
+      return [];
+    }
+    const res: TreeNodeModel[] = [];
+    const questionDataProxy = BABA.getProxy(BabaStr.QuestionDataProxy);
+    for (const qid of favoriteProxy.getFavoriteQuestionQids(hash)) {
+      let questionNode: TreeNodeModel | undefined = questionDataProxy.getNodeByQid(qid);
+      if (questionNode == undefined) {
+        questionNode = questionDataProxy.getNodeById(qid);
+      }
+      if (questionNode != undefined && this.canShow(questionNode)) {
+        const leafData = { ...questionNode.get_data(), input: hash, favoriteQuestionId: qid };
+        res.push(CreateTreeNodeModel(leafData, TreeNodeType.Tree_favorite_leaf));
+      }
+    }
+    return sortNodeList(res);
   }
 
   public getFavoriteNodes(): TreeNodeModel[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { RankScoreDataMediator, RankScoreDataProxy } from "./rankScore/RankScore
 import { TodayDataMediator, TodayDataProxy } from "./todayData/TodayDataModule";
 import { RecentContestMediator, RecentContestProxy } from "./recentContestData/RecentContestDataModule";
 import { ContestQuestionMediator, ContestQuestionProxy } from "./recentContestData/ContestQuestionDataModule";
+import { FavoriteDataMediator, FavoriteDataProxy } from "./favoriteData/FavoriteDataModule";
 
 //==================================BABA========================================
 
@@ -79,6 +80,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       RecentContestMediator,
       ContestQuestionProxy,
       ContestQuestionMediator,
+      FavoriteDataProxy,
+      FavoriteDataMediator,
     ]);
 
     // 资源管理

--- a/src/favoriteData/FavoriteDataModule.ts
+++ b/src/favoriteData/FavoriteDataModule.ts
@@ -1,0 +1,269 @@
+import { BABAMediator, BABAProxy, BabaStr, BaseCC, BABA } from "../BABA";
+import { OutPutType } from "../model/ConstDefind";
+import { ITreeDataNormal } from "../model/TreeNodeModel";
+import { promptForSignIn, ShowMessage } from "../utils/OutputUtils";
+
+export interface IFavoriteListInfo {
+  id_hash: string;
+  name: string;
+  slug: string;
+}
+
+interface IFavoriteListGraphQL {
+  idHash?: string;
+  name?: string;
+  questions?: Array<{ questionId?: string }>;
+}
+
+class FavoriteData {
+  lists: IFavoriteListInfo[] = [];
+  questionsByHash: Map<string, string[]> = new Map<string, string[]>();
+  listsLoaded: boolean = false;
+  loadingLists: boolean = false;
+  loadingQuestions: Set<string> = new Set<string>();
+
+  clear(): void {
+    this.lists = [];
+    this.questionsByHash.clear();
+    this.listsLoaded = false;
+    this.loadingLists = false;
+    this.loadingQuestions.clear();
+  }
+}
+
+const favoriteData: FavoriteData = new FavoriteData();
+
+function parseFavoriteLists(data: any): void {
+  const favoritesLists = data?.favoritesLists || {};
+  // 仅展示用户自建收藏夹，不包含官方题单(officialFavorites)或关注列表(watchedFavorites)
+  const allLists: IFavoriteListGraphQL[] = [...(favoritesLists.allFavorites || [])];
+  const seen = new Set<string>();
+  favoriteData.lists = [];
+  favoriteData.questionsByHash.clear();
+
+  for (const item of allLists) {
+    const idHash = item?.idHash;
+    const name = item?.name;
+    if (!idHash || !name || seen.has(idHash)) {
+      continue;
+    }
+    seen.add(idHash);
+    favoriteData.lists.push({
+      id_hash: idHash,
+      name,
+      slug: (item as any)?.slug || idHash,
+    });
+    const qids = (item.questions || [])
+      .map((q) => `${q?.questionId || ""}`)
+      .filter((qid) => qid.length > 0);
+    favoriteData.questionsByHash.set(idHash, qids);
+  }
+}
+
+function parseChildJson(raw: string): any {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) {
+    throw new Error("Empty response from leetcode query");
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (_e) {
+    throw new Error(`Invalid JSON response: ${trimmed.slice(0, 200)}`);
+  }
+}
+
+export class FavoriteDataProxy extends BABAProxy {
+  static NAME = BabaStr.FavoriteDataProxy;
+  constructor() {
+    super(FavoriteDataProxy.NAME);
+  }
+
+  public isListsLoaded(): boolean {
+    return favoriteData.listsLoaded;
+  }
+
+  public isLoadingLists(): boolean {
+    return favoriteData.loadingLists;
+  }
+
+  public isQuestionsLoaded(hash: string): boolean {
+    return favoriteData.questionsByHash.has(hash);
+  }
+
+  public isLoadingQuestions(hash: string): boolean {
+    return favoriteData.loadingQuestions.has(hash);
+  }
+
+  public getFavoriteListSlug(hash: string): string {
+    const list = favoriteData.lists.find((item) => item.id_hash === hash);
+    return list?.slug || hash;
+  }
+
+  public refreshFavoriteQuestionsUI(hash: string): void {
+    if (!hash) {
+      return;
+    }
+    BABA.sendNotification(BabaStr.TreeData_searchFavoriteQuestionsFinish, { hash });
+  }
+
+  public getAllFavoriteListTreeNodes(): ITreeDataNormal[] {
+    return favoriteData.lists.map((list) => ({
+      id: list.id_hash,
+      name: list.name,
+      input: list.slug,
+      rootNodeSortId: 6,
+    }));
+  }
+
+  public getFavoriteQuestionQids(hash: string): string[] {
+    return favoriteData.questionsByHash.get(hash) || [];
+  }
+
+  public removeQuestionFromList(hash: string, qid: string, fid?: string): void {
+    const qids = favoriteData.questionsByHash.get(hash);
+    if (!qids) {
+      return;
+    }
+    favoriteData.questionsByHash.set(
+      hash,
+      qids.filter((id) => id !== qid && (!fid || id !== fid))
+    );
+  }
+
+  public invalidateQuestionsCache(hash: string): void {
+    favoriteData.questionsByHash.delete(hash);
+  }
+
+  public addQuestionToList(hash: string, qid: string): void {
+    const qids = favoriteData.questionsByHash.get(hash) || [];
+    if (qids.includes(qid)) {
+      return;
+    }
+    favoriteData.questionsByHash.set(hash, qids.concat(qid));
+  }
+
+  public findFavoriteHashForQuestion(qid: string): string | undefined {
+    for (const [hash, qids] of favoriteData.questionsByHash.entries()) {
+      if (qids.includes(qid)) {
+        return hash;
+      }
+    }
+    return undefined;
+  }
+
+  public async searchFavoriteLists(force: boolean = false): Promise<void> {
+    const sbp = BABA.getProxy(BabaStr.StatusBarProxy);
+    if (!sbp.getUser()) {
+      promptForSignIn();
+      return;
+    }
+    if (favoriteData.loadingLists) {
+      return;
+    }
+    if (favoriteData.listsLoaded && !force) {
+      return;
+    }
+    favoriteData.loadingLists = true;
+    try {
+      const solution: string = await BABA.getProxy(BabaStr.ChildCallProxy)
+        .get_instance()
+        .getFavoriteLists();
+      const query_result = parseChildJson(solution);
+      if (query_result?.error) {
+        throw new Error(query_result.error);
+      }
+      parseFavoriteLists(query_result);
+      favoriteData.listsLoaded = true;
+      BABA.sendNotification(BabaStr.TreeData_searchFavoriteListsFinish);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      BABA.getProxy(BabaStr.LogOutputProxy).get_log().appendLine(`Favorite lists error: ${message}`);
+      await ShowMessage("Failed to fetch favorite lists. 请查看控制台信息~", OutPutType.error);
+    } finally {
+      favoriteData.loadingLists = false;
+    }
+  }
+
+  public async searchFavoriteQuestions(hash: string, force: boolean = false): Promise<void> {
+    const sbp = BABA.getProxy(BabaStr.StatusBarProxy);
+    if (!sbp.getUser()) {
+      promptForSignIn();
+      return;
+    }
+    if (!hash) {
+      return;
+    }
+    if (favoriteData.loadingQuestions.has(hash)) {
+      return;
+    }
+    if (favoriteData.questionsByHash.has(hash) && !force) {
+      return;
+    }
+    favoriteData.loadingQuestions.add(hash);
+    const favoriteSlug = this.getFavoriteListSlug(hash);
+    try {
+      const solution: string = await BABA.getProxy(BabaStr.ChildCallProxy)
+        .get_instance()
+        .getFavoriteQuestions(favoriteSlug, hash);
+      const query_result = parseChildJson(solution);
+      if (query_result?.error) {
+        throw new Error(query_result.error);
+      }
+      const questions = query_result?.favoriteQuestionList?.questions || [];
+      const qids = questions
+        .map((item) => `${item?.questionId || ""}`)
+        .filter((qid) => qid.length > 0);
+      favoriteData.questionsByHash.set(hash, qids);
+      BABA.sendNotification(BabaStr.TreeData_searchFavoriteQuestionsFinish, { hash });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      BABA.getProxy(BabaStr.LogOutputProxy)
+        .get_log()
+        .appendLine(`Favorite questions error (${hash}): ${message}`);
+      if (!favoriteData.questionsByHash.has(hash)) {
+        favoriteData.questionsByHash.set(hash, []);
+      }
+      BABA.sendNotification(BabaStr.TreeData_searchFavoriteQuestionsFinish, { hash });
+    } finally {
+      favoriteData.loadingQuestions.delete(hash);
+    }
+  }
+}
+
+export class FavoriteDataMediator extends BABAMediator {
+  static NAME = BabaStr.FavoriteDataMediator;
+  constructor() {
+    super(FavoriteDataMediator.NAME);
+  }
+
+  listNotificationInterests(): string[] {
+    return [
+      BabaStr.VSCODE_DISPOST,
+      BabaStr.USER_LOGIN_SUC,
+      BabaStr.USER_LOGIN_OUT,
+      BabaStr.BABACMD_refresh,
+      BabaStr.TreeData_favoriteChange,
+    ];
+  }
+
+  async handleNotification(_notification: BaseCC.BaseCC.INotification) {
+    switch (_notification.getName()) {
+      case BabaStr.VSCODE_DISPOST:
+        favoriteData.clear();
+        break;
+      case BabaStr.USER_LOGIN_SUC:
+      case BabaStr.BABACMD_refresh:
+        favoriteData.clear();
+        await BABA.getProxy(BabaStr.FavoriteDataProxy).searchFavoriteLists(true);
+        break;
+      case BabaStr.TreeData_favoriteChange:
+        await BABA.getProxy(BabaStr.FavoriteDataProxy).searchFavoriteLists(true);
+        break;
+      case BabaStr.USER_LOGIN_OUT:
+        favoriteData.clear();
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/src/model/TreeNodeModel.ts
+++ b/src/model/TreeNodeModel.ts
@@ -49,6 +49,8 @@ export interface IQuestionData {
   difficulty: string;
   passRate: string;
   companies: string[];
+  input?: string;
+  favoriteQuestionId?: string;
 }
 
 // 今天搬砖的点
@@ -112,6 +114,7 @@ export enum TreeNodeType {
   Tree_tag_fenlei_leaf = 10411, // tag
 
   Tree_favorite = 10500, // favorite
+  Tree_favorite_fenlei = 10510, // favorite list
   Tree_favorite_leaf = 10511, // 题目
 
   Tree_choice = 10600, // choice

--- a/src/rpc/actionChain/chainNode/core.ts
+++ b/src/rpc/actionChain/chainNode/core.ts
@@ -73,8 +73,12 @@ class CorePlugin extends ChainNodeBase {
   };
 
   /* It's a method that stars the problem. */
-  starProblem = (problem, starred, cb) => {
-    if (problem.starred === starred) {
+  starProblem = (problem, starred, cb, favoriteIdHash?) => {
+    if (favoriteIdHash) {
+      problem.favoriteIdHash = favoriteIdHash;
+    }
+    const targetHash = problem.favoriteIdHash;
+    if (problem.starred === starred && !targetHash) {
       return cb(null, starred);
     }
 
@@ -132,6 +136,21 @@ class CorePlugin extends ChainNodeBase {
       return cb(null, result);
     });
   };
+
+  getFavoriteLists = (cb) => {
+    (this as any).fetchFavoriteListsData(function (e, result) {
+      if (e) return cb(e);
+      return cb(null, result);
+    });
+  };
+
+  getFavoriteQuestions = (favoriteSlug, favoriteHash, cb) => {
+    (this as any).fetchFavoriteQuestionsData(favoriteSlug, favoriteHash, function (e, result) {
+      if (e) return cb(e);
+      return cb(null, result);
+    });
+  };
+
   getRating = (cb) => {
     this.getRatingOnline(function (e, result) {
       if (e) return cb(e);

--- a/src/rpc/actionChain/chainNode/leetcode.cn.ts
+++ b/src/rpc/actionChain/chainNode/leetcode.cn.ts
@@ -127,12 +127,16 @@ class LeetCodeCn extends ChainNodeBase {
     request.post(opts, function (e, resp, body) {
     e = checkError(e, resp, 200);
       if (e) return cb(e);
+      const record = body?.data?.todayRecord?.[0];
+      if (!record?.question) {
+        return cb(new Error("today question not available"));
+      }
       let result: any = {};
-      result.titleSlug = body.data.todayRecord[0].question.titleSlug;
-      result.questionId = body.data.todayRecord[0].question.questionId;
-      result.fid = body.data.todayRecord[0].question.questionFrontendId;
-      result.date = body.data.todayRecord[0].data;
-      result.userStatus = body.data.todayRecord[0].userStatus;
+      result.titleSlug = record.question.titleSlug;
+      result.questionId = record.question.questionId;
+      result.fid = record.question.questionFrontendId;
+      result.date = record.date;
+      result.userStatus = record.userStatus;
       return cb(null, result);
     });
   };

--- a/src/rpc/actionChain/chainNode/leetcode.ts
+++ b/src/rpc/actionChain/chainNode/leetcode.ts
@@ -467,36 +467,48 @@ server to get the problem's description, test cases, and other information. */
   /* A function that is used to star a problem. */
   starProblem = (problem, starred, cb) => {
     const user = sessionUtils.getUser();
-    const operationName = starred ? "addQuestionToFavorite" : "removeQuestionFromFavorite";
-    const opts = makeOpts(configUtils.sys.urls.graphql);
-    opts.headers.Origin = configUtils.sys.urls.base;
-    opts.headers.Referer = problem.link;
+    const hash = problem.favoriteIdHash || user.hash;
+    const questionId = "" + (problem.favoriteQuestionId || problem.id);
 
-    opts.json = true;
-    opts.body = {
-      query: `mutation ${operationName}($favoriteIdHash: String!, $questionId: String!) {\n  ${operationName}(favoriteIdHash: $favoriteIdHash, questionId: $questionId) {\n    ok\n    error\n    favoriteIdHash\n    questionId\n    __typename\n  }\n}\n`,
-      variables: { favoriteIdHash: user.hash, questionId: "" + problem.id },
-      operationName: operationName,
+    const starWithRest = () => {
+      const deleteUrl = configUtils.sys.urls.favorite_delete
+        .replace(/\$hash/g, hash)
+        .replace(/\$id/g, questionId);
+      const opts = makeOpts(starred ? configUtils.sys.urls.favorites : deleteUrl);
+      opts.headers.Origin = configUtils.sys.urls.base;
+      opts.headers.Referer = configUtils.isCN()
+        ? "https://leetcode.cn/problem-list/"
+        : problem.link || configUtils.sys.urls.base + "/";
+
+      if (starred) {
+        opts.method = "POST";
+        opts.json = true;
+        opts.body = {
+          favorite_id_hash: hash,
+          question_id: questionId,
+        };
+      } else {
+        opts.method = "DELETE";
+      }
+
+      const finishRest = (e: any, resp: any) => {
+        e = checkError(e, resp, 204);
+        if (e) return cb(e);
+        return cb(null, starred);
+      };
+
+      if (configUtils.isCN()) {
+        request(opts, function (e: any, resp: any) {
+          finishRest(e, resp);
+        });
+      } else {
+        request(opts, function (e: any, resp: any) {
+          finishRest(e, resp);
+        });
+      }
     };
 
-    if (configUtils.isCN()) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      request.post(opts, function (e: any, resp: any, _) {
-        e = checkError(e, resp, 200);
-        if (e) return cb(e);
-        return cb(null, starred);
-      });
-    } else {
-
-      opts.json = opts.body
-      delete opts.body
-      this.h2request.post(opts, function (e, resp, _) {
-        e = checkError(e, resp, 200);
-        if (e) return cb(e);
-        return cb(null, starred);
-      });
-
-    }
+    starWithRest();
   };
 
   h2request = {
@@ -540,6 +552,217 @@ server to get the problem's description, test cases, and other information. */
     }
   }
 
+
+  getFavoriteListsGraphQL = (cb) => {
+    const opts = makeOpts(configUtils.sys.urls.graphql);
+    opts.headers.Origin = configUtils.sys.urls.base;
+    opts.headers.Referer = configUtils.isCN()
+      ? "https://leetcode.cn/problem-list/"
+      : configUtils.sys.urls.base;
+    opts.json = true;
+    opts.body = {
+      operationName: "allFavorites",
+      variables: {},
+      query: [
+        "query allFavorites {",
+        "  favoritesLists {",
+        "    allFavorites {",
+        "      idHash",
+        "      name",
+        "      isPublicFavorite",
+        "      questions {",
+        "        questionId",
+        "        titleSlug",
+        "      }",
+        "    }",
+        "  }",
+        "}",
+      ].join("\n"),
+    };
+
+    const handleGraphQLBody = (body, cb) => {
+      if (body?.errors?.length) {
+        return cb(new Error(body.errors.map((item) => item.message).join("; ")));
+      }
+      if (!body?.data?.favoritesLists) {
+        return cb(new Error("Invalid favorites GraphQL response"));
+      }
+      return cb(null, body.data);
+    };
+
+    if (configUtils.isCN()) {
+      request.post(opts, function (e, resp, body) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        return handleGraphQLBody(body, cb);
+      });
+    } else {
+      opts.json = opts.body;
+      delete opts.body;
+      this.h2request.post(opts, function (e, resp, body) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        return handleGraphQLBody(body, cb);
+      });
+    }
+  };
+
+  getFavoriteQuestionsGraphQL = (favoriteSlug, cb) => {
+    const opts = makeOpts(configUtils.sys.urls.graphql);
+    opts.headers.Origin = configUtils.sys.urls.base;
+    opts.headers.Referer = configUtils.isCN()
+      ? "https://leetcode.cn/problem-list/"
+      : configUtils.sys.urls.base;
+    opts.json = true;
+    opts.body = {
+      operationName: "favoriteQuestionList",
+      variables: { favoriteSlug, limit: 5000 },
+      query: [
+        "query favoriteQuestionList($favoriteSlug: String!, $limit: Int) {",
+        "  favoriteQuestionList(favoriteSlug: $favoriteSlug, limit: $limit) {",
+        "    questions {",
+        "      questionId",
+        "      titleSlug",
+        "    }",
+        "  }",
+        "}",
+      ].join("\n"),
+    };
+
+    const handleGraphQLBody = (body, cb) => {
+      if (body?.errors?.length) {
+        return cb(new Error(body.errors.map((item) => item.message).join("; ")));
+      }
+      if (!body?.data?.favoriteQuestionList) {
+        return cb(new Error("Invalid favoriteQuestionList GraphQL response"));
+      }
+      return cb(null, body.data);
+    };
+
+    if (configUtils.isCN()) {
+      request.post(opts, function (e, resp, body) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        return handleGraphQLBody(body, cb);
+      });
+    } else {
+      opts.json = opts.body;
+      delete opts.body;
+      this.h2request.post(opts, function (e, resp, body) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        return handleGraphQLBody(body, cb);
+      });
+    }
+  };
+
+  getFavoriteQuestionsREST = (favoriteHash, cb) => {
+    const url = configUtils.sys.urls.favorites.replace(/\/$/, "") + "/" + favoriteHash + "/";
+    const opts = makeOpts(url);
+    opts.headers.Referer = configUtils.isCN()
+      ? "https://leetcode.cn/problem-list/"
+      : configUtils.sys.urls.base;
+
+    if (!configUtils.isCN()) {
+      this.h2request.get(opts, function (e, resp, data) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        const questions = data?.questions || [];
+        return cb(null, {
+          favoriteQuestionList: {
+            questions: questions.map((item) => ({
+              questionId: `${item?.question_id || item?.frontend_question_id || ""}`,
+              titleSlug: item?.title_slug || item?.slug || "",
+            })),
+          },
+        });
+      });
+    } else {
+      request.get(opts, function (e, resp, body) {
+        e = checkError(e, resp, 200);
+        if (e) return cb(e);
+        let data;
+        try {
+          data = typeof body === "string" ? JSON.parse(body) : body;
+        } catch (parseError) {
+          return cb(parseError);
+        }
+        const questions = data?.questions || [];
+        return cb(null, {
+          favoriteQuestionList: {
+            questions: questions.map((item) => ({
+              questionId: `${item?.question_id || item?.frontend_question_id || ""}`,
+              titleSlug: item?.title_slug || item?.slug || "",
+            })),
+          },
+        });
+      });
+    }
+  };
+
+  fetchFavoriteQuestionsData = (favoriteSlug, favoriteHash, cb) => {
+    const that = this;
+    const tryGraphQL = (slug, next) => {
+      this.getFavoriteQuestionsGraphQL(slug, function (e, result) {
+        if (!e && result?.favoriteQuestionList) {
+          return cb(null, result);
+        }
+        next(e);
+      });
+    };
+
+    tryGraphQL(favoriteSlug, function (e1) {
+      if (favoriteHash && favoriteHash !== favoriteSlug) {
+        tryGraphQL(favoriteHash, function (e2) {
+          that.getFavoriteQuestionsREST(favoriteHash, function (e3, restResult) {
+            if (e3) return cb(e3 || e2 || e1);
+            return cb(null, restResult);
+          });
+        });
+      } else {
+        that.getFavoriteQuestionsREST(favoriteHash || favoriteSlug, function (e3, restResult) {
+          if (e3) return cb(e3 || e1);
+          return cb(null, restResult);
+        });
+      }
+    });
+  };
+
+  getFavoriteListsFromREST = (cb) => {
+    this.getFavorites(function (e, favorites) {
+      if (e) return cb(e);
+      const privateFavorites = favorites?.favorites?.private_favorites || [];
+      const allFavorites = privateFavorites
+        .filter((item) => item?.id_hash && item?.name)
+        .map((item) => ({
+          idHash: item.id_hash,
+          slug: item.slug || item.id_hash,
+          name: item.name,
+          questions: [],
+        }));
+      return cb(null, { favoritesLists: { allFavorites } });
+    });
+  };
+
+  fetchFavoriteListsData = (cb) => {
+    const that = this;
+    this.getFavoriteListsGraphQL(function (e, result) {
+      const all = result?.favoritesLists?.allFavorites || [];
+      if (!e && all.length > 0) {
+        return cb(null, result);
+      }
+      that.getFavoriteListsFromREST(function (e2, restResult) {
+        if (e2) {
+          return cb(e || e2);
+        }
+        return cb(null, restResult);
+      });
+    });
+  };
+
+  getFavoriteQuestions = (favoriteSlug, favoriteHash, cb) => {
+    this.fetchFavoriteQuestionsData(favoriteSlug, favoriteHash, cb);
+  };
 
   /* Making a request to the server to get the favorites. */
   getFavorites = (cb: any) => {
@@ -956,7 +1179,7 @@ and csrf token to the user object and saves the user object to the session. */
   getQuestionOfToday = (cb) => {
     const opts = makeOpts(configUtils.sys.urls.graphql);
     opts.headers.Origin = configUtils.sys.urls.base;
-    opts.headers.Referer = "https://leetcode.com/";
+    opts.headers.Referer = configUtils.sys.urls.base + "/";
 
     opts.json = true;
     opts.body = {
@@ -971,15 +1194,6 @@ and csrf token to the user object and saves the user object to the session. */
         "      titleSlug",
         "      questionId",
         "      questionFrontendId",
-        // '      content',
-        // '      stats',
-        // '      likes',
-        // '      dislikes',
-        // '      codeDefinition',
-        // '      sampleTestCase',
-        // '      enableRunCode',
-        // '      metaData',
-        // '      translatedContent',
         "      __typename",
         "    }",
         "  __typename",
@@ -988,18 +1202,25 @@ and csrf token to the user object and saves the user object to the session. */
       ].join("\n"),
     };
 
-    // request.post(opts, function (e, resp, body) {
-    //   e = checkError(e, resp, 200);
-    //   if (e) return cb(e);
-    //   let result: any = {};
-    //   result.titleSlug = body.data.todayRecord[0].question.titleSlug;
-    //   result.questionId = body.data.todayRecord[0].question.questionId;
-    //   result.fid = body.data.todayRecord[0].question.questionFrontendId;
-    //   result.date = body.data.todayRecord[0].data;
-    //   result.userStatus = body.data.todayRecord[0].userStatus;
-    //   return cb(null, result);
-    // });
-    cb(null, {});
+    if (configUtils.isCN()) {
+      return cb(new Error("today question handler missing"));
+    }
+
+    this.h2request.post(opts, function (e, resp, body) {
+      e = checkError(e, resp, 200);
+      if (e) return cb(e);
+      const record = body?.data?.todayRecord?.[0];
+      if (!record?.question) {
+        return cb(new Error("today question not available"));
+      }
+      let result: any = {};
+      result.titleSlug = record.question.titleSlug;
+      result.questionId = record.question.questionId;
+      result.fid = record.question.questionFrontendId;
+      result.date = record.date;
+      result.userStatus = record.userStatus;
+      return cb(null, result);
+    });
   };
 
 

--- a/src/rpc/actionChain/chainNodeBase.ts
+++ b/src/rpc/actionChain/chainNodeBase.ts
@@ -105,7 +105,10 @@ export class ChainNodeBase {
     this.next.getProblem(keyword, needTranslation, cb);
   }
 
-  public starProblem(problem, starred, cb: Function): void {
+  public starProblem(problem, starred, cb: Function, favoriteIdHash?: string): void {
+    if (favoriteIdHash) {
+      problem.favoriteIdHash = favoriteIdHash;
+    }
     this.next.starProblem(problem, starred, cb);
   }
   public exportProblem(problem, opts): void {
@@ -139,5 +142,13 @@ export class ChainNodeBase {
   }
   public getHintsOnline(problem, cb: Function): void {
     this.next.getHintsOnline(problem, cb);
+  }
+
+  public getFavoriteLists(cb: Function): void {
+    this.next.getFavoriteLists(cb);
+  }
+
+  public getFavoriteQuestions(favoriteSlug: string, favoriteHash: string, cb: Function): void {
+    this.next.getFavoriteQuestions(favoriteSlug, favoriteHash, cb);
   }
 }

--- a/src/rpc/factory/api/queryApi.ts
+++ b/src/rpc/factory/api/queryApi.ts
@@ -86,6 +86,24 @@ class QueryApi extends ApiBase {
         default: false,
         describe: "get Question list of a contest",
       })
+      .option("k", {
+        alias: "getFavoriteLists",
+        type: "boolean",
+        default: false,
+        describe: "getFavoriteLists",
+      })
+      .option("l", {
+        alias: "getFavoriteQuestions",
+        type: "string",
+        default: "",
+        describe: "getFavoriteQuestions slug",
+      })
+      .option("m", {
+        alias: "favoriteHash",
+        type: "string",
+        default: "",
+        describe: "favorite list hash for REST fallback",
+      })
       .option("z", {
         alias: "test",
         type: "string",
@@ -103,9 +121,14 @@ class QueryApi extends ApiBase {
 
   call(argv) {
     sessionUtils.argv = argv;
+    const replyError = (e: any) => {
+      const message = e?.msg || e?.message || String(e);
+      const statusCode = e?.statusCode;
+      reply.info(JSON.stringify(statusCode ? { error: message, statusCode } : { error: message }));
+    };
     if (argv.a) {
       chainMgr.getChainHead().getTodayQuestion(function (e, result) {
-        if (e) return;
+        if (e) return replyError(e);
         reply.info(JSON.stringify(result));
       });
     } else if (argv.b) {
@@ -135,7 +158,7 @@ class QueryApi extends ApiBase {
       });
     } else if (argv.d) {
       chainMgr.getChainHead().filterProblems(argv, function (e, problems) {
-        if (e) return reply.info(e);
+        if (e) return replyError(e);
         let new_objcet: Array<any> = [];
         problems.forEach((element) => {
           let temp_ele: any = {};
@@ -167,14 +190,25 @@ class QueryApi extends ApiBase {
           });
         });
       }
-    } if (argv.i) {
+    } else if (argv.i) {
       chainMgr.getChainHead().getRecentContest(function (e, result) {
-        if (e) return;
+        if (e) return replyError(e);
         reply.info(JSON.stringify(result));
       });
-    } if (argv.j) {
+    } else if (argv.j) {
       chainMgr.getChainHead().getContestQuestion(argv.j, function (e, result) {
-        if (e) return;
+        if (e) return replyError(e);
+        reply.info(JSON.stringify(result));
+      });
+    } else if (argv.k) {
+      chainMgr.getChainHead().getFavoriteLists(function (e, result) {
+        if (e) return replyError(e);
+        reply.info(JSON.stringify(result));
+      });
+    } else if (argv.l) {
+      const favoriteHash = argv.m || argv.l;
+      chainMgr.getChainHead().getFavoriteQuestions(argv.l, favoriteHash, function (e, result) {
+        if (e) return replyError(e);
         reply.info(JSON.stringify(result));
       });
     } else if (argv.z) {

--- a/src/rpc/factory/api/starApi.ts
+++ b/src/rpc/factory/api/starApi.ts
@@ -13,6 +13,22 @@ import { sessionUtils } from "../../utils/sessionUtils";
 import { ApiBase } from "../apiBase";
 import { chainMgr } from "../../actionChain/chainManager";
 
+function formatError(e: any): string {
+  if (!e) {
+    return "unknown error";
+  }
+  if (typeof e === "string") {
+    return e;
+  }
+  if (e instanceof Error) {
+    return e.message;
+  }
+  if (e.msg) {
+    return e.statusCode ? `${e.msg} [code=${e.statusCode}]` : e.msg;
+  }
+  return String(e);
+}
+
 class StarApi extends ApiBase {
   constructor() {
     super();
@@ -25,6 +41,12 @@ class StarApi extends ApiBase {
         type: "boolean",
         describe: "Unstar question",
         default: false,
+      })
+      .option("H", {
+        alias: "favoriteHash",
+        type: "string",
+        default: "",
+        describe: "Target favorite list hash",
       })
       .positional("keyword", {
         type: "string",
@@ -39,15 +61,55 @@ class StarApi extends ApiBase {
 
   call(argv) {
     sessionUtils.argv = argv;
-    // translation doesn't affect question lookup
-    chainMgr.getChainHead().getProblem(argv.keyword, true, function (e, problem) {
-      if (e) return reply.info(e);
+    const favoriteHash = argv.H || argv.favoriteHash || "";
+    const replyError = (e: any): never => {
+      reply.info(JSON.stringify({ error: formatError(e) }));
+      process.exit(1);
+    };
 
-      chainMgr.getChainHead().starProblem(problem, !argv.delete, function (e, flag) {
-        if (e) return reply.info(e);
-        chainMgr.getChainHead().updateProblem(problem, { starred: flag });
-        reply.info(`[${problem.fid}] ${problem.name} ${flag ? "icon.like" : "icon.unlike"}`);
-      });
+    chainMgr.getChainHead().getProblems(false, function (e, problems) {
+      if (e) return replyError(e);
+
+      const keyword = argv.keyword;
+      const normalized = Number(keyword) || keyword;
+      let problem;
+      if (favoriteHash) {
+        // Favorite list GraphQL questionId is backend question_id; avoid fid-only collisions.
+        problem = problems.find(function (x) {
+          return x.id + "" === normalized + "";
+        });
+        if (!problem) {
+          problem = {
+            id: normalized,
+            fid: normalized,
+            name: keyword,
+            favoriteIdHash: favoriteHash,
+            favoriteQuestionId: normalized,
+          };
+        } else {
+          problem.favoriteIdHash = favoriteHash;
+          problem.favoriteQuestionId = normalized;
+        }
+      } else {
+        problem = problems.find(function (x) {
+          return x.id + "" === normalized + "" || x.fid + "" === normalized + "";
+        });
+      }
+      if (!problem) {
+        return replyError(new Error(`Problem not found: ${keyword}`));
+      }
+
+      chainMgr.getChainHead().starProblem(
+        problem,
+        !argv.delete,
+        function (e, flag) {
+          if (e) return replyError(e);
+          chainMgr.getChainHead().updateProblem(problem, { starred: flag });
+          reply.info(`[${problem.fid}] ${problem.name} ${flag ? "icon.like" : "icon.unlike"}`);
+          process.exit(0);
+        }
+      );
+      return;
     });
   }
 }

--- a/src/todayData/TodayDataModule.ts
+++ b/src/todayData/TodayDataModule.ts
@@ -86,6 +86,9 @@ export class TodayDataProxy extends BABAProxy {
         .get_instance()
         .getTodayQuestion(needTranslation);
       const query_result = JSON.parse(solution);
+      if (query_result?.error) {
+        throw new Error(query_result.error);
+      }
       // "{\"titleSlug\":\"number-of-dice-rolls-with-target-sum\",\"questionId\":\"1263\",\"fid\":\"1155\",\"userStatus\":\"NOT_START\"}\n"
 
       // const titleSlug: string = query_result.titleSlug

--- a/src/treeData/TreeDataService.ts
+++ b/src/treeData/TreeDataService.ts
@@ -120,7 +120,10 @@ export class TreeDataService implements vscode.TreeDataProvider<TreeNodeModel> {
         return treeViewController.getAllNodes();
       }
       else if (element.nodeType == TreeNodeType.Tree_favorite) {
-        return treeViewController.getFavoriteNodes();
+        return treeViewController.getFavoriteListChild();
+      }
+      else if (element.nodeType == TreeNodeType.Tree_favorite_fenlei) {
+        return treeViewController.getFavoriteQuestionNodes(element);
       }
       else if (element.nodeType == TreeNodeType.Tree_difficulty) {
         return treeViewController.getDifficultyChild()
@@ -412,6 +415,8 @@ export class TreeDataMediator extends BABAMediator {
       BabaStr.ConfigChange_hideScore,
       BabaStr.ConfigChange_SortStrategy,
       BabaStr.TreeData_favoriteChange,
+      BabaStr.TreeData_searchFavoriteListsFinish,
+      BabaStr.TreeData_searchFavoriteQuestionsFinish,
       BabaStr.USER_statusChanged,
       BabaStr.statusBar_update_statusFinish,
       BabaStr.StartReadData,
@@ -501,7 +506,11 @@ export class TreeDataMediator extends BABAMediator {
         break;
       case BabaStr.TreeData_searchUserContestFinish:
       case BabaStr.TreeData_favoriteChange:
-        treeDataService.refresh();
+        treeDataService.fire();
+        break;
+      case BabaStr.TreeData_searchFavoriteListsFinish:
+      case BabaStr.TreeData_searchFavoriteQuestionsFinish:
+        treeDataService.fire();
         break;
       case BabaStr.QuestionData_ReBuildQuestionDataFinish:
       case BabaStr.TreeData_searchTodayFinish:

--- a/src/utils/SystemUtils.ts
+++ b/src/utils/SystemUtils.ts
@@ -185,6 +185,25 @@ export async function sysCall(
 ): Promise<string> {
   return new Promise((resolve: (res: string) => void, reject: (e: Error) => void): void => {
     let result: string = "";
+    let settled = false;
+    const finishResolve = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        childProc.kill();
+      } catch (_e) {
+        // ignore kill errors when process already exited
+      }
+      resolve(result);
+    };
+    const tryResolveStarSuccess = () => {
+      if (!result.includes("icon.like") && !result.includes("icon.unlike")) {
+        return;
+      }
+      finishResolve();
+    };
     let childProc: cp.ChildProcess;
     if (useVscodeNode() && command == "node") {
       let newargs: string[] = [];
@@ -192,7 +211,7 @@ export async function sysCall(
       for (let arg_index = 1; arg_index < args.length; arg_index++) {
         newargs.push(args[arg_index]);
       }
-      let new_opt = { silent: true, ...options, env: createEnvOption() };
+      let new_opt = { silent: true, execArgv: [], ...options, env: createEnvOption() };
       childProc = cp.fork(command, newargs, new_opt);
     } else {
       childProc = cp.spawn(command, args, {
@@ -205,6 +224,7 @@ export async function sysCall(
       data = data.toString();
       result = result.concat(data);
       BABA.getProxy(BabaStr.LogOutputProxy).get_log().append(data);
+      tryResolveStarSuccess();
     });
 
     childProc.stderr?.on("data", (data: string | Buffer) =>
@@ -214,16 +234,41 @@ export async function sysCall(
     childProc.on("error", reject);
 
     childProc.on("close", (code: number) => {
+      if (settled) {
+        return;
+      }
       let try_result_json;
       try {
-        try_result_json = JSON.parse(result);
+        try_result_json = JSON.parse(result.trim());
       } catch (e) {
         try_result_json;
       }
-      if (code !== 0 || (try_result_json ? try_result_json.code < 0 : result.indexOf("ERROR") > -1)) {
+      const hasHardError =
+        code !== 0 || (try_result_json ? try_result_json.code < 0 : result.indexOf("ERROR") > -1);
+      if (hasHardError) {
+        if (result.includes("icon.like") || result.includes("icon.unlike")) {
+          resolve(result);
+          return;
+        }
+        if (try_result_json?.error) {
+          reject(new Error(try_result_json.error));
+          return;
+        }
+        if (result.includes("[object Object]")) {
+          reject(new Error("command failed"));
+          return;
+        }
+        if (code !== 0 && result.trim().length > 0 && try_result_json && !try_result_json.error) {
+          resolve(result);
+          return;
+        }
         const error = new Error(`exit code "${code}". ${result || ""}`);
         reject(error);
       } else {
+        if (try_result_json?.error) {
+          reject(new Error(try_result_json.error));
+          return;
+        }
         resolve(result);
       }
     });
@@ -242,6 +287,15 @@ function childLCPTCTX(): string {
 export function createEnvOption(): {} {
   const proxy: string | undefined = getHttpAgent();
   const env: any = Object.create(process.env);
+  const nodeOptions = `${env.NODE_OPTIONS || ""}`
+    .replace(/--inspect(?:-port|-brk)?(?:=[^\s]+)?/g, "")
+    .replace(/--debug(?:-port|-brk)?(?:=[^\s]+)?/g, "")
+    .trim();
+  if (nodeOptions) {
+    env.NODE_OPTIONS = nodeOptions;
+  } else {
+    delete env.NODE_OPTIONS;
+  }
   if (proxy) {
     env.http_proxy = proxy;
     return env;


### PR DESCRIPTION
## 使用了AI进行编程

## 功能概要
- 新增 FavoriteDataModule，Favorite 树改为三级：Favorite -> 收藏夹 -> 题目
- GraphQL allFavorites 内嵌题目作为数据源，展开子收藏夹不再反复网络拉取
- star 命令支持 -H favoriteHash，对指定收藏夹 REST 增删题目
- query 新增 -k(收藏夹列表) / -l(题目 slug) / -m(hash) 子进程接口

## 改动文件
- 新增: src/favoriteData/FavoriteDataModule.ts
- 树与命令: TreeViewController, TreeDataService, TreeNodeModel, extension, BABA
- RPC: leetcode.ts, starApi.ts, queryApi.ts, core.ts, chainNodeBase.ts, leetcode.cn.ts
- 子进程与工具: childCallModule.ts, SystemUtils.ts, TodayDataModule.ts

## 保留的功能性修复及原因
1. parseFavoriteLists 始终写入 questionsByHash（含空数组） 原因：空收藏夹无缓存时会反复触发 searchFavoriteQuestions，导致无限刷新
2. getFavoriteQuestionNodes 不再自动 searchFavoriteQuestions 原因：题目已在 allFavorites 内嵌返回；额外请求常 404 且覆盖缓存
3. TreeData_favoriteChange 不再 favoriteData.clear() 原因：clear 重置 loadingLists，与进行中的 searchFavoriteLists 竞态，反复弹「正在获取收藏夹」
4. add/removeFavorite 使用 favoriteOpQueue 串行 原因：并发 removeQuestionFromList 读改写竞态，后写覆盖前写，只删掉最后一题
5. starApi 有 -H 时仅按 backend question_id 匹配，DELETE 用 favoriteQuestionId 原因：fid 与 GraphQL questionId 撞号时会删错题，API 成功但刷新后题目仍在
6. remove 流程：先 API 成功，再更新本地缓存并 fire 树 原因：避免乐观更新掩盖 API 失败，刷新后题目复现
7. sysCall 检测 icon.like/unlike 后立即 resolve 并 kill 子进程 原因：F5 调试下子进程挂起调试器不触发 close，进度条永不消失、UI 不更新
8. starApi 完成后 process.exit(0/1) 原因：子进程默认不退出，拖长等待时间
9. assertStarCommandResult 从多行 stdout 提取成功行 原因：调试器日志混在输出中导致校验失败
10. createEnvOption 剥离 --inspect，fork 使用 execArgv:[] 原因：F5 继承 NODE_OPTIONS 导致子进程调试崩溃
11. queryApi 统一 replyError JSON / TodayDataModule 解析 error 原因：子进程失败时扩展端无法感知错误